### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ planned features
 * Advanced querying options including searching
 * Remove reliance on Firebase and make it compatible with any realtime backend
 
-####Getting Started
+#### Getting Started
 Include firebase-resource.js in your index.html file. Suggest creating a services folder.
 
     <script src="/services/firebase_resource.js"></script>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
